### PR TITLE
[wip] MVP: Adding basic version for bot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM golang:1.10.0 as builder
+WORKDIR /go/src/github.com/zewa-crit/zewa-bot/
+COPY main.go .
+RUN go get -d -v github.com/bwmarrin/discordgo \
+  && CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o bot .
+
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+WORKDIR /root/
+COPY --from=builder /go/src/github.com/zewa-crit/zewa-bot/bot .
+CMD ["./bot"] 
+LABEL "maintainer"="zewa-crit" \
+      "org.label-schema.base-image.name"="alpine" \
+      "org.label-schema.base-image.version"="latest" \ 
+      "org.label-schema.description"="zewa discord bot" \
+      "org.label-schema.vcs-url"="https://github.com/zewa-crit/zewa-bot" \
+      "org.label-schema.schema-version"="1.0.0-rc.1" \
+      "org.label-schema.vcs-ref"=$VCS_REF \
+      "org.label-schema.version"=$VERSION \
+      "org.label-schema.build-date"=$BUILD_DATE 

--- a/README.md
+++ b/README.md
@@ -6,40 +6,8 @@ Branch | Status
 master | [![](http://dockerbuildbadges.quelltext.eu/status.svg?organization=zewacrit&repository=zewa-bot)](https://hub.docker.com/r/zewacrit/zewa-bot/builds/)
 dev-pingbot | [![](http://dockerbuildbadges.quelltext.eu/status.svg?organization=zewacrit&repository=zewa-bot&tag=dev-pingbot)](https://hub.docker.com/r/zewacrit/zewa-bot/builds/)
 
-## Welcome to GitHub Pages
+## Welcome to Zewa-Crit
 
-You can use the [editor on GitHub](https://github.com/zewa-crit/zewa-bot/edit/master/README.md) to maintain and preview the content for your website in Markdown files.
+### Aim for this project
 
-Whenever you commit to this repository, GitHub Pages will run [Jekyll](https://jekyllrb.com/) to rebuild the pages in your site, from the content in your Markdown files.
-
-### Markdown
-
-Markdown is a lightweight and easy-to-use syntax for styling your writing. It includes conventions for
-
-```markdown
-Syntax highlighted code block
-
-# Header 1
-## Header 2
-### Header 3
-
-- Bulleted
-- List
-
-1. Numbered
-2. List
-
-**Bold** and _Italic_ and `Code` text
-
-[Link](url) and ![Image](src)
-```
-
-For more details see [GitHub Flavored Markdown](https://guides.github.com/features/mastering-markdown/).
-
-### Jekyll Themes
-
-Your Pages site will use the layout and styles from the Jekyll theme you have selected in your [repository settings](https://github.com/zewa-crit/zewa-bot/settings). The name of this theme is saved in the Jekyll `_config.yml` configuration file.
-
-### Support or Contact
-
-Having trouble with Pages? Check out our [documentation](https://help.github.com/categories/github-pages-basics/) or [contact support](https://github.com/contact) and we’ll help you sort it out.
+Make our lives cooler

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # zewa-bot
 Discord bot for our server and for our needs
+
 Branch | Status
 ------ | ------
 master | [![](http://dockerbuildbadges.quelltext.eu/status.svg?organization=zewacrit&repository=zewa-bot)](https://hub.docker.com/r/zewacrit/zewa-bot/builds/)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # zewa-bot
 Discord bot for our server and for our needs
+
+[![](http://dockerbuildbadges.quelltext.eu/status.svg?organization=zewacrit&repository=zewa-bot)](https://hub.docker.com/r/zewacrit/zewa-bot/builds/)

--- a/main.go
+++ b/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	// defacto default library for working with discord API
+	"github.com/bwmarrin/discordgo"
+)
+
+// Environment parameters used for vars to be set on startup
+//
+var (
+	// Token: The discord oauth2 token generated in
+	// https://discordapp.com/developers/applications/me; defaults to unset
+	Token string
+
+	// BotPrefix: The string prefix to identify direct Bot commands and
+	// to not have unwanted bot activities while chatting; defaults to "!"
+	BotPrefix string
+
+	// BotID: The id of the user object; defaults to unset
+	BotID string
+)
+
+func main() {
+	// Default BotPrefix to "!", then check if env var is set.
+	// if "BotPrefix" env is set override default value.
+	BotPrefix = "!"
+	if bp := os.Getenv("BotPrefix"); bp != "" {
+		BotPrefix = bp
+	}
+
+	// Get the env var value for the oauth2 token
+    // os.Setenv("DC_TOKEN","")
+	Token = os.Getenv("DC_TOKEN")
+
+	// Construct a new session and connect to the bot with oauth token,
+	// then get the session object
+	dg, err := discordgo.New("Bot " + Token)
+	if err != nil {
+		fmt.Println("error creating Discord session,", err)
+		return
+	}
+
+	// Get user object for active user; Who am I ?
+	u, err := dg.User("@me")
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+
+	// User ID from active user object, from the bot itself.
+	BotID = u.ID
+
+	// Add message handler before opening the session to the bot. 
+	dg.AddHandler(messageHandler)
+	err = dg.Open()
+
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+
+	fmt.Println("Bot is running")
+
+	// keep bot running for now.
+	<-make(chan struct{})
+	return
+
+}
+
+// simple message handler thats answers an ping command
+func messageHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
+
+	// If I'm the author Ignore the message even if triggered.
+	if m.Author.ID == BotID {
+		return
+	}
+
+	if m.Content == "ping" {
+		// Send given string to channel where the trigger was send from.
+		_, _ = s.ChannelMessageSend(m.ChannelID, "pong")
+	}
+
+	fmt.Println(m.Content)
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	// defacto default library for wokring with discord API
+	"github.com/bwmarrin/discordgo"
+)
+
+//"NDE5ODgwMDUzMzI5ODg3MjM1.DX2oAQ.YoBHnuY4ag6HvJ1uJopgZ5bivBM"
+
+// Environment parameters used for vars to be set on startup
+//
+var (
+	// Token: The discord oauth2 token generated in
+	// https://discordapp.com/developers/applications/me; defaults to unset
+	Token string
+
+	// BotPrefix: The string prefix to identify direct Bot commands and
+	// to not have unwanted bot activities while chatting; defaults to "!"
+	BotPrefix string
+
+	// BotID: The id of the user object; defaults to unset
+	BotID string
+)
+
+func main() {
+	// Default BotPrefix to "!", then check if env var is set.
+	// if "BotPrefix" env is set override default value.
+	BotPrefix = "!"
+	if bp := os.Getenv("BotPrefix"); bp != "" {
+		BotPrefix = bp
+	}
+
+	// Get the env var value for the oauth2 token
+
+	Token = os.Getenv("DC_TOKEN")
+
+	// Construct a new session and connect to the bot with oauth token,
+	// then get the session object
+	dg, err := discordgo.New("Bot " + Token)
+	if err != nil {
+		fmt.Println("error creating Discord session,", err)
+		return
+	}
+
+	// Get user object for active user; Who am I ?
+	u, err := dg.User("@me")
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+
+	// User ID from active user object, from the bot itself.
+	BotID = u.ID
+
+	// Add message handler before opening the session to the bot. 
+	dg.AddHandler(messageHandler)
+	err = dg.Open()
+
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+
+	fmt.Println("Bot is running")
+
+	// keep bot running for now.
+	<-make(chan struct{})
+	return
+
+}
+
+// simple message handler thats answers an ping command
+func messageHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
+
+	// If I'm the author Ignore the message even if triggered.
+	if m.Author.ID == BotID {
+		return
+	}
+
+	if m.Content == "ping" {
+		// Send given string to channel where the trigger was send from.
+		_, _ = s.ChannelMessageSend(m.ChannelID, "pong")
+	}
+
+	fmt.Println(m.Content)
+}


### PR DESCRIPTION
Addresses #1 

- [x] Add a simple go bot with the discrodgo library
- [x] Connects to discord servers the bot is invited to through oauth token and discord API
- [x] Reads the chat in the server channels and replies to trigger word ping

ToDO

- [x]  Created automated build with docker hub